### PR TITLE
Update providers/default.rb

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -25,6 +25,7 @@ end
 action :enable do
   # use load instead of require to ensure the handler file
   # is reloaded into memory each chef run. fixes COOK-620
+  handler = nil
   converge_by("load #{@new_resource.source}") do
      begin
        Object.send(:remove_const, klass)


### PR DESCRIPTION
Scope fix to make handler visible in the second block. Will otherwise break when used with ruby 1.9.3p194 . (CLA already provided a while ago).
