### PR TITLE
[COOK-3071] Avoid reloading handler at each run

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -28,3 +28,5 @@ else
 end
 
 default["chef_handler"]["handler_path"] = "#{File.expand_path(File.join(Chef::Config[:file_cache_path], '..'))}/handlers"
+
+default["chef_handler"]["handler_copy_path"] = File.join(Chef::Config[:file_cache_path], 'handlers_copy')


### PR DESCRIPTION
http://tickets.opscode.com/browse/COOK-3071

Using a cache for the source file of handler we are able to compare what is supposed to be loaded in chef context and the source of the handler.
To handle case where chef context has disappeared we try to load the class.
This technique works only if this provider is the only one to modify handlers context.

I have tested the part avoiding to reload the handler at each run. I have not tested yet the part testing if the handler is absent from chef context.
