### PR TITLE
COOK-4117: use the correct scope when searching the children class name

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -88,6 +88,6 @@ end
 
 def klass
   @klass ||= begin
-    @new_resource.class_name.split('::').inject(Kernel) { |scope, const_name| scope.const_get(const_name) }
+    @new_resource.class_name.split('::').inject(Kernel) { |scope, const_name| scope.const_get(const_name, scope === Kernel) }
   end
 end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -88,6 +88,10 @@ end
 
 def klass
   @klass ||= begin
+    # we need to search the ancestors only for the
+    # first/uppermost namespace of the class, so we need
+    # to enable the #const_get inherit paramenter only when
+    # we are searching in Kernel scope (see COOK-4117).
     @new_resource.class_name.split('::').inject(Kernel) { |scope, const_name| scope.const_get(const_name, scope === Kernel) }
   end
 end


### PR DESCRIPTION
https://tickets.opscode.com/browse/COOK-4117
