### PR TITLE
README: Add Ruby 1.9 as required

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Creates a configured handler path for distributing [Chef report and exception ha
 Requirements
 ============
 
-* Ruby 1.9
+* Ruby >= 1.9
 
 Attributes
 ==========

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@ Description
 
 Creates a configured handler path for distributing [Chef report and exception handlers](http://docs.opscode.com/handlers.html).  Also exposes an LWRP for enabling Chef handlers from within recipe code (as opposed to hard coding in the client.rb file).  This is useful for cookbook authors who may want to ship a product specific handler (see the `cloudkick` cookbook for an example) with their cookbook.
 
+Requirements
+============
+
+* Ruby 1.9
+
 Attributes
 ==========
 


### PR DESCRIPTION
Since release [v1.1.5](https://github.com/opscode-cookbooks/chef_handler/blob/master/CHANGELOG.md#v115-2014-02-25) this cookbook requires Ruby 1.9.

Related to issue #16.
