### PR TITLE
Modifies resource to use root_group and root_user.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,13 +18,4 @@
 # limitations under the License.
 #
 
-default['chef_handler']['root_user'] = 'root'
-
-case platform
-when 'openbsd', 'freebsd', 'mac_os_x', 'mac_os_x_server'
-  default['chef_handler']['root_group'] = 'wheel'
-else
-  default['chef_handler']['root_group'] = 'root'
-end
-
 default['chef_handler']['handler_path'] = "#{File.expand_path(File.join(Chef::Config[:file_cache_path], '..'))}/handlers"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,10 +22,10 @@ Chef::Log.info("Chef Handlers will be at: #{node['chef_handler']['handler_path']
 
 remote_directory node['chef_handler']['handler_path'] do
   source 'handlers'
+  owner node['root_user']
+  group node['root_group']
   # Just inherit permissions on Windows, don't try to set POSIX perms
   if node['platform'] != 'windows'
-    owner node['chef_handler']['root_user']
-    group node['chef_handler']['root_group']
     mode '0755'
     recursive true
   end


### PR DESCRIPTION
/cc @juliandunn 

These are Ohai attributes that should be available for all platforms. I
see no need to require them to be duplicated in this cookbook.
