### PR TITLE
Modifies the resource to use root_group attribute.

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -18,13 +18,4 @@
 # limitations under the License.
 #
 
-default['chef_handler']['root_user'] = 'root'
-
-case platform
-when 'openbsd', 'freebsd', 'mac_os_x', 'mac_os_x_server'
-  default['chef_handler']['root_group'] = 'wheel'
-else
-  default['chef_handler']['root_group'] = 'root'
-end
-
 default['chef_handler']['handler_path'] = "#{File.expand_path(File.join(Chef::Config[:file_cache_path], '..'))}/handlers"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -22,12 +22,11 @@ Chef::Log.info("Chef Handlers will be at: #{node['chef_handler']['handler_path']
 
 remote_directory node['chef_handler']['handler_path'] do
   source 'handlers'
-  # Just inherit permissions on Windows, don't try to set POSIX perms
-  if node['platform'] != 'windows'
-    owner node['chef_handler']['root_user']
-    group node['chef_handler']['root_group']
+  unless platform?('windows')
+    owner 'root'
     mode '0755'
     recursive true
   end
+  group node['root_group']
   action :nothing
 end.run_action(:create)


### PR DESCRIPTION
/cc @tas50 @pburkholder

This modifies the cookbook to use the Ohai attribute for obtaining the root group of the system. It fixes some errors that we've been observing on the AIX and Solaris platforms. This should close out #25.
