### PR TITLE
Use ohai root_user attribute in place of root

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache 2.0'
 description 'Distribute and enable Chef Exception and Report handlers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '1.3.0'
+version '1.3.1'
 
 recipe 'chef_handler', 'Deploys all handlers to the handler path early during the run.'
 recipe 'chef_handler::json_file', 'Enables Chef::Handler::JsonFile to serialize run status data to /var/chef/reports.'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -23,7 +23,7 @@ Chef::Log.info("Chef Handlers will be located at: #{node['chef_handler']['handle
 remote_directory node['chef_handler']['handler_path'] do
   source 'handlers'
   unless platform?('windows')
-    owner 'root'
+    owner node['root_user']
     mode '0755'
     recursive true
   end


### PR DESCRIPTION
### Description

Allows consumers to override the default attribute of 'root' while not duplicating ohai attributes. This is important for platforms like cygwin that aren't windows but which may not have a root user or with a different superuser.
### Issues Resolved
### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD
