### PR TITLE
support handlers as library files.

### DIFF
--- a/.kitchen.docker.yml
+++ b/.kitchen.docker.yml
@@ -42,4 +42,4 @@ platforms:
 
 suites:
   - name: default
-    run_list: chef_handler::default
+    run_list: test::default

--- a/Gemfile
+++ b/Gemfile
@@ -1,24 +1,13 @@
 source 'https://rubygems.org'
 
-group :rake do
-  gem 'rake'
-  gem 'tomlrb'
-end
-
-group :lint do
-  gem 'foodcritic', '~> 6.0'
-  gem 'rubocop', '~> 0.37'
-end
-
-group :unit do
-  gem 'berkshelf', '~> 4.1'
-  gem 'chefspec', '~> 4.5'
-end
-
-group :kitchen_common do
-  gem 'test-kitchen', '~> 1.5'
-end
-
-group :kitchen_vagrant do
-  gem 'kitchen-vagrant', '~> 0.19'
-end
+gem 'rake'
+gem 'tomlrb'
+gem 'foodcritic', '~> 6.0'
+gem 'rubocop', '~> 0.37'
+gem 'berkshelf', '~> 4.1'
+gem 'chefspec', '~> 4.5'
+gem 'test-kitchen', '~> 1.5'
+gem 'kitchen-vagrant', '~> 0.19'
+gem 'kitchen-docker'
+gem 'winrm-fs'
+gem 'stove'

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ It is best to declare `chef_handler` resources early on in the compile phase so 
 
 #### Attribute Parameters
 - `class_name:` name attribute. The name of the handler class (can be module name-spaced).
-- `source:` full path to the handler file.  can also be a gem path if the handler ships as part of a Ruby gem.
+- `source:` full path to the handler file.  can also be a gem path if the handler ships as part of a Ruby gem.  can also be nil, in which case the file must be loaded as a library.
 - `arguments:` an array of arguments to pass the handler's class initializer
 - `supports:` type of Chef Handler to register as, i.e. :report, :exception or both. default is `:report => true, :exception => true`
 
@@ -68,6 +68,12 @@ It is best to declare `chef_handler` resources early on in the compile phase so 
     chef_handler "CloudkickHandler" do
       source "#{node['chef_handler']['handler_path']}/cloudkick_handler.rb"
       arguments [node['cloudkick']['oauth_key'], node['cloudkick']['oauth_secret']]
+      action :enable
+    end
+
+    # enable the MyCorp::MyLibraryHandler handler which was dropped off in a
+    # standard chef library file.
+    chef_handler "MyCorp::MyLibraryHandler" do
       action :enable
     end
 ```

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -38,11 +38,15 @@ action :enable do
   end
 
   handler = nil
-  converge_by("load #{class_name} from #{new_resource.source}") do
-    require new_resource.source
-    _, klass = get_class(class_name)
-    handler = klass.send(:new, *collect_args(new_resource.arguments))
+
+  unless new_resource.source.nil?
+    converge_by("load #{class_name} from #{new_resource.source}") do
+      require new_resource.source
+    end
   end
+
+  _, klass = get_class(class_name)
+  handler = klass.send(:new, *collect_args(new_resource.arguments))
 
   new_resource.supports.each do |type, enable|
     next unless enable

--- a/test/fixtures/cookbooks/test/libraries/my_library_handler.rb
+++ b/test/fixtures/cookbooks/test/libraries/my_library_handler.rb
@@ -1,0 +1,9 @@
+module MyCorp
+  class MyLibraryHandler < Chef::Handler
+    def report
+      puts "The run status was: #{run_status.respond_to?(:updated_resources) ? run_status.updated_resources.length : 0}"
+      puts "The total resource count was: #{run_status.respond_to?(:all_resources) ? run_status.all_resources.length : 0}"
+      puts "The elapsed time was: #{run_status.elapsed_time}"
+    end
+  end
+end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -6,10 +6,9 @@ end
 
 chef_handler 'MyCorp::MyHandler' do
   source "#{node['chef_handler']['handler_path']}/my_handler.rb"
-  action :enable
+  action [ :enable, :disable ]
 end
 
-chef_handler 'MyCorp::MyHandler' do
-  source "#{node['chef_handler']['handler_path']}/my_handler.rb"
-  action :disable
+chef_handler 'MyCorp::MyLibraryHandler' do
+  action :enable
 end


### PR DESCRIPTION
- cleans up the Gemfile
- kitchen docker now uses the fixture and tests more than the
  remote_directory resource
- source of nil will skip requiring the file, so the class must
  be loaded via another mechanism (i.e. probably just throwing it
  into a library file).
