### PR TITLE
yanking out converge_by

### DIFF
--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,27 +32,25 @@ action :enable do
   class_name = new_resource.class_name
   new_resource.supports.each do |type, enable|
     next unless enable
-      unregister_handler(type, class_name)
+    unregister_handler(type, class_name)
   end
 
   handler = nil
 
-  unless new_resource.source.nil?
-      require new_resource.source
-  end
+  require new_resource.source unless new_resource.source.nil?
 
   _, klass = get_class(class_name)
   handler = klass.send(:new, *collect_args(new_resource.arguments))
 
   new_resource.supports.each do |type, enable|
     next unless enable
-      register_handler(type, handler)
+    register_handler(type, handler)
   end
 end
 
 action :disable do
   new_resource.supports.each_key do |type|
-      unregister_handler(type, new_resource.class_name)
+    unregister_handler(type, new_resource.class_name)
   end
 end
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -32,17 +32,13 @@ action :enable do
   class_name = new_resource.class_name
   new_resource.supports.each do |type, enable|
     next unless enable
-    converge_by("disable #{class_name} as a #{type} handler") do
       unregister_handler(type, class_name)
-    end
   end
 
   handler = nil
 
   unless new_resource.source.nil?
-    converge_by("load #{class_name} from #{new_resource.source}") do
       require new_resource.source
-    end
   end
 
   _, klass = get_class(class_name)
@@ -50,17 +46,13 @@ action :enable do
 
   new_resource.supports.each do |type, enable|
     next unless enable
-    converge_by("enable #{new_resource} as a #{type} handler") do
       register_handler(type, handler)
-    end
   end
 end
 
 action :disable do
   new_resource.supports.each_key do |type|
-    converge_by("disable #{new_resource} as a #{type} handler") do
       unregister_handler(type, new_resource.class_name)
-    end
   end
 end
 


### PR DESCRIPTION
### Description

This removes several needless `converge_by` lines which only cause the resource to gratuitously be marked as updated on each chef-client run.  Enabling/Disabling Handlers should not affect the updated status of any Chef resources if not desired.

### Issues Resolved

closes #27 

### Check List
- [x] All tests pass. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] The CLA has been signed. See https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD


Signed-off-by: Jeremy J. Miller <jm@chef.io>