### PR TITLE
[GH-50] Access resource class through resolver API

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -12,3 +12,7 @@ recipe 'chef_handler::json_file', 'Enables Chef::Handler::JsonFile to serialize 
 source_url 'https://github.com/chef-cookbooks/chef_handler'
 issues_url 'https://github.com/chef-cookbooks/chef_handler/issues'
 chef_version '>= 12.1' if respond_to?(:chef_version)
+
+%w(ubuntu debian redhat centos fedora).each do |os|
+  supports os
+end

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -55,7 +55,7 @@ action :disable do
 end
 
 def load_current_resource
-  @current_resource = Chef::Resource::ChefHandler.new(new_resource.name)
+  @current_resource = Chef::Resource.resource_for_node(new_resource.declared_type, run_context.node).new(new_resource.name)
   @current_resource.class_name(new_resource.class_name)
   @current_resource.source(new_resource.source)
   @current_resource


### PR DESCRIPTION
### Description

Custom resources/providers no longer get module constants in Chef 13. Instead they need to be looked up through Chef's resolver API https://discourse.chef.io/t/chef-client-13-released/10735

Signed-off-by: sshao <sshao@users.noreply.github.com>

### Issues Resolved

https://github.com/chef-cookbooks/chef_handler/issues/50

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
