### PR TITLE
Deprecates 'supports' attribute in default resource.

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It is best to declare `chef_handler` resources early on in the compile phase so 
 - `class_name:` name attribute. The name of the handler class (can be module name-spaced).
 - `source:` full path to the handler file.  can also be a gem path if the handler ships as part of a Ruby gem.  can also be nil, in which case the file must be loaded as a library.
 - `arguments:` an array of arguments to pass the handler's class initializer
-- `supports:` type of Chef Handler to register as, i.e. :report, :exception or both. default is `:report => true, :exception => true`
+- `handler_type:` type of Chef Handler to register as, i.e. :report, :exception or both. default is `:report => true, :exception => true`
 
 #### Example
 
@@ -56,7 +56,7 @@ It is best to declare `chef_handler` resources early on in the compile phase so 
     chef_handler "Chef::Handler::JsonFile" do
       source "chef/handler/json_file"
       arguments :path => '/var/chef/reports'
-      supports :exception => true
+      handler_type :exception => true
       action :enable
     end
 
@@ -94,7 +94,7 @@ chef_handler provides built in [chefspec](https://github.com/sethvargo/chefspec)
   expect(runner).to enable_chef_handler("Chef::Handler::JsonFile").with(
     source: "chef/handler/json_file",
     arguments: { :path => '/var/chef/reports'},
-    supports: {:exception => true}
+    handler_type: {:exception => true}
     )
   end
 ```

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Distribute and enable Chef Exception and Report handlers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.2.1'
+version '2.2.0'
 
 recipe 'chef_handler', 'Deploys all handlers to the handler path early during the run.'
 recipe 'chef_handler::json_file', 'Enables Chef::Handler::JsonFile to serialize run status data to /var/chef/reports.'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@chef.io'
 license 'Apache-2.0'
 description 'Distribute and enable Chef Exception and Report handlers'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.1.1'
+version '2.2.1'
 
 recipe 'chef_handler', 'Deploys all handlers to the handler path early during the run.'
 recipe 'chef_handler::json_file', 'Enables Chef::Handler::JsonFile to serialize run status data to /var/chef/reports.'

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -30,7 +30,7 @@ end
 # load that file.  It then instantiates that class by name and registers it as a handler.
 action :enable do
   class_name = new_resource.class_name
-  new_resource.supports.each do |type, enable|
+  new_resource.handler_type.each do |type, enable|
     next unless enable
     unregister_handler(type, class_name)
   end
@@ -42,14 +42,14 @@ action :enable do
   _, klass = get_class(class_name)
   handler = klass.send(:new, *collect_args(new_resource.arguments))
 
-  new_resource.supports.each do |type, enable|
+  new_resource.handler_type.each do |type, enable|
     next unless enable
     register_handler(type, handler)
   end
 end
 
 action :disable do
-  new_resource.supports.each_key do |type|
+  new_resource.handler_type.each_key do |type|
     unregister_handler(type, new_resource.class_name)
   end
 end

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -23,17 +23,15 @@ actions :enable, :disable
 state_attrs :arguments,
             :class_name,
             :source,
-            :supports
+            :handler_type
 
 attribute :class_name, kind_of: String, name_attribute: true
 attribute :source, default: nil, kind_of: String
 attribute :arguments, default: []
-attribute :supports, kind_of: Hash, default: { report: true, exception: true }
+attribute :handler_type, kind_of: Hash, default: { report: true, exception: true }
 
-# we have to set default for the supports attribute
-# in initializer since it is a 'reserved' attribute name
 def initialize(*args)
   super
   @action = :enable
-  @supports = { report: true, exception: true }
+  @handler_type = { report: true, exception: true }
 end


### PR DESCRIPTION
### Description

- Per https://docs.chef.io/deprecations_property_name_collision.html, Chef 13 will bail on runs where a resource property name collides.
- Replaces 'supports' with 'handler_type' which jibes nicely with an argument name found in the helpers.
- Signed-off-by: Ryan Frantz <ryanleefrantz@gmail.com>

### Issues Resolved

Resolves Chef 13 deprecation issues described in https://docs.chef.io/deprecations_property_name_collision.html

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
