### PR TITLE
Fix namespace collision with helper module

### DIFF
--- a/resources/default.rb
+++ b/resources/default.rb
@@ -57,7 +57,7 @@ action :disable do
 end
 
 action_class do
-  include ChefHandler::Helpers
+  include ::ChefHandler::Helpers
 
   def collect_args(resource_args = [])
     if resource_args.is_a? Array

--- a/spec/unit/recipes/json_file_spec.rb
+++ b/spec/unit/recipes/json_file_spec.rb
@@ -1,0 +1,41 @@
+# Author:: Chris Crebolder <ccrebolder@gmail.com>
+# Copyright:: Copyright (c) 2017 Chef, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+require 'spec_helper'
+
+describe 'chef_handler::json_file' do
+  context 'when using ChefSpec::ServerRunner' do
+    let(:server_run) do
+      runner = ChefSpec::ServerRunner.new(platform: 'ubuntu', version: '16.04')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { server_run }.to_not raise_error
+    end
+  end
+
+  context 'when using ChefSpec::SoloRunner' do
+    let(:solo_run) do
+      runner = ChefSpec::SoloRunner.new(platform: 'ubuntu', version: '16.04')
+      runner.converge(described_recipe)
+    end
+
+    it 'converges successfully' do
+      expect { solo_run }.to_not raise_error
+    end
+  end
+end


### PR DESCRIPTION
### Description

This change ensures we include the helpers module using the top-level namespace, as the custom resource itself is a class with the name ChefHandler.

### Issues Resolved

#62 

### Check List

- [x] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
- [x] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
